### PR TITLE
Secure param and agw resource id ref. Fixes #77

### DIFF
--- a/reference-implementations/AppGW-IAPIM-Func/bicep/gateway/appgw.bicep
+++ b/reference-implementations/AppGW-IAPIM-Func/bicep/gateway/appgw.bicep
@@ -170,7 +170,7 @@ resource appGatewayName_resource 'Microsoft.Network/applicationGateways@2019-09-
           pickHostNameFromBackendAddress: false
           requestTimeout: 20
           probe: {
-            id: '${resourceId('Microsoft.Network/applicationGateways', appGatewayName)}/probes/APIM'
+            id: resourceId('Microsoft.Network/applicationGateways/probes', appGatewayName, 'APIM')
           }
         }
       }
@@ -180,10 +180,10 @@ resource appGatewayName_resource 'Microsoft.Network/applicationGateways@2019-09-
         name: 'default'
         properties: {
           frontendIPConfiguration: {
-            id: '${resourceId('Microsoft.Network/applicationGateways', appGatewayName)}/frontendIPConfigurations/appGwPublicFrontendIp'
+            id: resourceId('Microsoft.Network/applicationGateways/frontendIPConfigurations', appGatewayName, 'appGwPublicFrontendIp')
           }
           frontendPort: {
-            id: '${resourceId('Microsoft.Network/applicationGateways', appGatewayName)}/frontendPorts/port_80'
+            id: resourceId('Microsoft.Network/applicationGateways/frontendPorts', appGatewayName, 'port_80')
           }
           protocol: 'Http'
           hostnames: []
@@ -194,14 +194,14 @@ resource appGatewayName_resource 'Microsoft.Network/applicationGateways@2019-09-
         name: 'https'
         properties: {
           frontendIPConfiguration: {
-            id: '${resourceId('Microsoft.Network/applicationGateways', appGatewayName)}/frontendIPConfigurations/appGwPublicFrontendIp'
+            id: resourceId('Microsoft.Network/applicationGateways/frontendIPConfigurations', appGatewayName, 'appGwPublicFrontendIp')
           }
           frontendPort: {
-            id: '${resourceId('Microsoft.Network/applicationGateways', appGatewayName)}/frontendPorts/port_443'
+            id: resourceId('Microsoft.Network/applicationGateways/frontendPorts', appGatewayName, 'port_443')
           }
           protocol: 'Https'
           sslCertificate: {
-            id: '${resourceId('Microsoft.Network/applicationGateways', appGatewayName)}/sslCertificates/${appGatewayFQDN}'
+            id: resourceId('Microsoft.Network/applicationGateways/sslCertificates', appGatewayName, appGatewayFQDN)
           }
           hostnames: []
           requireServerNameIndication: false
@@ -215,13 +215,13 @@ resource appGatewayName_resource 'Microsoft.Network/applicationGateways@2019-09-
         properties: {
           ruleType: 'Basic'
           httpListener: {
-            id: '${resourceId('Microsoft.Network/applicationGateways', appGatewayName)}/httpListeners/https'
+            id: resourceId('Microsoft.Network/applicationGateways/httpListeners', appGatewayName, 'https')
           }
           backendAddressPool: {
-            id: '${resourceId('Microsoft.Network/applicationGateways', appGatewayName)}/backendAddressPools/apim'
+            id: resourceId('Microsoft.Network/applicationGateways/backendAddressPools', appGatewayName, 'apim')
           }
           backendHttpSettings: {
-            id: '${resourceId('Microsoft.Network/applicationGateways', appGatewayName)}/backendHttpSettingsCollection/https'
+            id: resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', appGatewayName, 'https')
           }
         }
       }

--- a/reference-implementations/AppGW-IAPIM-Func/bicep/main.bicep
+++ b/reference-implementations/AppGW-IAPIM-Func/bicep/main.bicep
@@ -18,6 +18,7 @@ param environment string
 param vmUsername string
 
 @description('The password for the Administrator user for all VMs created by this deployment')
+@secure()
 param vmPassword string
 
 @description('The CI/CD platform to be used, and for which an agent will be configured for the ASE deployment. Specify \'none\' if no agent needed')

--- a/reference-implementations/AppGW-IAPIM-Func/bicep/shared/createvmwindows.bicep
+++ b/reference-implementations/AppGW-IAPIM-Func/bicep/shared/createvmwindows.bicep
@@ -15,6 +15,7 @@ param vmSize string = 'Standard_D4_v3'
 param username string
 
 @description('The password for the Administrator user for all VMs created by this deployment')
+@secure()
 param password string
 
 @description('Windows OS Version indicator')

--- a/reference-implementations/AppGW-IAPIM-Func/bicep/shared/shared.bicep
+++ b/reference-implementations/AppGW-IAPIM-Func/bicep/shared/shared.bicep
@@ -13,6 +13,7 @@ param CICDAgentSubnetId string
 param vmUsername string
 
 @description('The password for the Administrator user for all VMs created by this deployment')
+@secure()
 param vmPassword string
 
 @description('The CI/CD platform to be used, and for which an agent will be configured for the ASE deployment. Specify \'none\' if no agent needed')


### PR DESCRIPTION
Fixes #77 

On running the pipeline, the following warnings/errors occur...

`Error: WARNING: /home/runner/work/apim-landing-zone-accelerator/apim-landing-zone-accelerator/reference-implementations/AppGW-IAPIM-Func/bicep/shared/createvmwindows.bicep(18,7) : Warning secure-secrets-in-params: Parameter 'password' may represent a secret (according to its name) and must be declared with the '@secure()' attribute. [https://aka.ms/bicep/linter/secure-secrets-in-params]
`

Then various iterations of...

`/home/runner/work/apim-landing-zone-accelerator/apim-landing-zone-accelerator/reference-implementations/AppGW-IAPIM-Func/bicep/gateway/appgw.bicep(183,13) : Warning use-resource-id-functions: If property "id" represents a resource ID, it must use a symbolic resource reference, be a parameter or start with one of these functions: extensionResourceId, guid, if, reference, resourceId, subscription, subscriptionResourceId, tenantResourceId. [https://aka.ms/bicep/linter/use-resource-id-functions]`

Issue 1 requires the VMPassword to be set as a secure parameter.

Issue 2 requires a reformat of the resource id references within the app gateway config. For example...

`resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', appGatewayName, 'https')`