### PR TITLE
Change app service plan and functions to new versions of these resource types

### DIFF
--- a/reference-implementations/AppGW-IAPIM-Func/terraform/main.tf
+++ b/reference-implementations/AppGW-IAPIM-Func/terraform/main.tf
@@ -81,7 +81,6 @@ module "backend" {
   source            = "./modules/backend"
   resource_suffix   = module.resource_suffix.name
   workload_name     = var.workload_name
-  os_type           = var.os_type
   location          = local.resource_location
   backend_subnet_id = module.networking.backend_subnet_id
 }

--- a/reference-implementations/AppGW-IAPIM-Func/terraform/module.md
+++ b/reference-implementations/AppGW-IAPIM-Func/terraform/module.md
@@ -40,7 +40,6 @@ No resources.
 | <a name="input_cicd_agent_type"></a> [cicd\_agent\_type](#input\_cicd\_agent\_type) | The CI/CD platform to be used, and for which an agent will be configured for the ASE deployment. Specify 'none' if no agent needed') | `string` | n/a | yes |
 | <a name="input_deployment_environment"></a> [deployment\_environment](#input\_deployment\_environment) | The environment for which the deployment is being executed | `string` | `"dev"` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location in which the deployment is happening | `string` | `"East US"` | no |
-| <a name="input_os_type"></a> [os\_type](#input\_os\_type) | A string indicating the Operating System type for this function app | `string` | `"linux"` | no |
 | <a name="input_personal_access_token"></a> [personal\_access\_token](#input\_personal\_access\_token) | Azure DevOps or GitHub personal access token (PAT) used to setup the CI/CD agent | `string` | n/a | yes |
 | <a name="input_pool_name"></a> [pool\_name](#input\_pool\_name) | The name Azure DevOps or GitHub pool for this build agent to join. Use 'Default' if you don't have a separate pool | `string` | n/a | yes |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | n/a | `string` | `"001"` | no |

--- a/reference-implementations/AppGW-IAPIM-Func/terraform/modules/backend/main.tf
+++ b/reference-implementations/AppGW-IAPIM-Func/terraform/modules/backend/main.tf
@@ -59,7 +59,7 @@ resource "azurerm_function_app" "function_app" {
   os_type                    = var.os_type
   storage_account_name       = azurerm_storage_account.backend_storage_account.name
   storage_account_access_key = azurerm_storage_account.backend_storage_account.primary_access_key
-  version                    = "~3"
+  version                    = "~4"
   app_settings = {
     "WEBSITE_RUN_FROM_PACKAGE" = "",
     "FUNCTIONS_WORKER_RUNTIME" = "dotnet",
@@ -95,7 +95,7 @@ resource "azurerm_function_app" "function_app_container" {
   os_type                    = var.os_type
   storage_account_name       = azurerm_storage_account.backend_storage_account.name
   storage_account_access_key = azurerm_storage_account.backend_storage_account.primary_access_key
-  version                    = "~3"
+  version                    = "~4"
 
   app_settings = {
     "WEBSITE_RUN_FROM_PACKAGE" = "",

--- a/reference-implementations/AppGW-IAPIM-Func/terraform/modules/backend/module.md
+++ b/reference-implementations/AppGW-IAPIM-Func/terraform/modules/backend/module.md
@@ -19,9 +19,9 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_app_service_plan.function_app_asp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_plan) | resource |
-| [azurerm_function_app.function_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/function_app) | resource |
-| [azurerm_function_app.function_app_container](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/function_app) | resource |
+| [azurerm_service_plan.function_app_service_plan](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_plan) | resource |
+| [azurerm_linux_function_app.function_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_function_app) | resource |
+| [azurerm_linux_function_app.function_app_container](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_function_app) | resource |
 | [azurerm_resource_group.backend_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_storage_account.backend_storage_account](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
 
@@ -33,7 +33,6 @@ No modules.
 | <a name="input_asp_tier"></a> [asp\_tier](#input\_asp\_tier) | n/a | `string` | `"premium"` | no |
 | <a name="input_backend_subnet_id"></a> [backend\_subnet\_id](#input\_backend\_subnet\_id) | Backend resources subnet id | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The location of the apim instance | `string` | n/a | yes |
-| <a name="input_os_type"></a> [os\_type](#input\_os\_type) | A string indicating the Operating System type for this function app | `any` | n/a | yes |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | n/a | `string` | n/a | yes |
 | <a name="input_storage_account_tier"></a> [storage\_account\_tier](#input\_storage\_account\_tier) | Defines the Tier to use for this storage account. Valid options are Standard and Premium. For BlockBlobStorage and FileStorage accounts only Premium is valid. Changing this forces a new resource to be created. | `string` | `"standard"` | no |
 | <a name="input_storage_replication_type"></a> [storage\_replication\_type](#input\_storage\_replication\_type) | Defines the type of replication to use for this storage account. Valid options are LRS, GRS, RAGRS, ZRS, GZRS and RAGZRS. Changing this forces a new resource to be created. | `string` | `"LRS"` | no |

--- a/reference-implementations/AppGW-IAPIM-Func/terraform/modules/backend/outputs.tf
+++ b/reference-implementations/AppGW-IAPIM-Func/terraform/modules/backend/outputs.tf
@@ -1,4 +1,4 @@
 output "app_service_plan_id" {
   description = "The resource id of the app service plan"
-  value       = azurerm_app_service_plan.function_app_asp.id
+  value       = azurerm_service_plan.function_app_service_plan.id
 }

--- a/reference-implementations/AppGW-IAPIM-Func/terraform/modules/backend/variables.tf
+++ b/reference-implementations/AppGW-IAPIM-Func/terraform/modules/backend/variables.tf
@@ -18,22 +18,13 @@ variable "storage_replication_type" {
   description = "Defines the type of replication to use for this storage account. Valid options are LRS, GRS, RAGRS, ZRS, GZRS and RAGZRS. Changing this forces a new resource to be created."
 }
 
-variable "os_type" {
-  description = "A string indicating the Operating System type for this function app"
-}
-
 variable "resource_suffix" {
   description = ""
   type        = string
 }
 
-variable "asp_tier" {
-  default = "premium"
-  type    = string
-}
-
-variable "asp_size" {
-  default = "p1v2"
+variable "sp_sku" {
+  default = "P1v2"
   type    = string
 }
 

--- a/reference-implementations/AppGW-IAPIM-Func/terraform/modules/gateway/main.tf
+++ b/reference-implementations/AppGW-IAPIM-Func/terraform/modules/gateway/main.tf
@@ -210,6 +210,7 @@ resource "azurerm_application_gateway" "network" {
     http_listener_name         = "https"
     backend_address_pool_name  = "apim"
     backend_http_settings_name = "https"
+    priority                   = 100
   }
 
   probe {

--- a/reference-implementations/AppGW-IAPIM-Func/terraform/variables.tf
+++ b/reference-implementations/AppGW-IAPIM-Func/terraform/variables.tf
@@ -82,12 +82,6 @@ variable "app_gateway_certificate_type" {
 }
 
 # Backend resource variables
-variable "os_type" {
-  type        = string
-  description = "A string indicating the Operating System type for this function app"
-  default     = "linux"
-}
-
 variable "vm_username" {
   type        = string
   description = "Agent VM username"


### PR DESCRIPTION
Three changes:
1. Some resource types have been deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. These are replaced as follows:
   ```
   azurerm_app_service_plan -> azurerm_service_plan
   azurerm_function_app     -> azurerm_linux_function_app
   ```
1. Increment the Azure Functions runtime version from 3 (soon to be deprecated) to 4.
1. [Bugfix] Set the priority of the request AppGW routing rule. (Couldn't deploy without this.)

Tested by a successful deployment after fixing the issue described in the last item.