### PR TITLE
bicep deploy cleanup.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "azureFunctions.deploySubpath": "components\\Azure Functions\\APIMCSDemoAzFunc/bin/Release/netcoreapp3.1/publish",
     "azureFunctions.projectLanguage": "C#",
-    "azureFunctions.projectRuntime": "~3",
+    "azureFunctions.projectRuntime": "~4",
     "debug.internalConsoleOptions": "neverOpen",
     "azureFunctions.preDeployTask": "publish (functions)"
 }

--- a/reference-implementations/AppGW-IAPIM-Func/bicep/apim/apim.bicep
+++ b/reference-implementations/AppGW-IAPIM-Func/bicep/apim/apim.bicep
@@ -1,11 +1,11 @@
-targetScope='resourceGroup'
+targetScope = 'resourceGroup'
 
 /*
  * Input parameters
 */
 
 @description('The name of the API Management resource to be created.')
-param apimName            string
+param apimName string
 
 @description('The subnet resource id to use for APIM.')
 @minLength(1)
@@ -32,48 +32,48 @@ param appInsightsName string
 param appInsightsId string
 param appInsightsInstrumentationKey string
 
+param publicIpAddressId string
 /*
  * Resources
 */
 
-resource apimName_resource 'Microsoft.ApiManagement/service@2020-12-01' = {
+resource apimName_resource 'Microsoft.ApiManagement/service@2022-08-01' = {
   name: apimName
   location: location
-  sku:{
+  sku: {
     capacity: capacity
     name: skuName
   }
-  properties:{
+  properties: {
     virtualNetworkType: 'Internal'
     publisherEmail: publisherEmail
     publisherName: publisherName
+    publicIpAddressId: publicIpAddressId
     virtualNetworkConfiguration: {
       subnetResourceId: apimSubnetId
     }
   }
-}
 
-resource apimName_appInsightsLogger_resource 'Microsoft.ApiManagement/service/loggers@2019-01-01' = {
-  parent: apimName_resource
-  name: appInsightsName
-  properties: {
-    loggerType: 'applicationInsights'
-    resourceId: appInsightsId
-    credentials: {
-      instrumentationKey: appInsightsInstrumentationKey
+  resource apimName_appInsightsLogger_resource 'loggers' = {
+    name: appInsightsName
+    properties: {
+      loggerType: 'applicationInsights'
+      resourceId: appInsightsId
+      credentials: {
+        instrumentationKey: appInsightsInstrumentationKey
+      }
     }
   }
-}
 
-resource apimName_applicationinsights 'Microsoft.ApiManagement/service/diagnostics@2019-01-01' = {
-  parent: apimName_resource
-  name: 'applicationinsights'
-  properties: {
-    loggerId: apimName_appInsightsLogger_resource.id
-    alwaysLog: 'allErrors'
-    sampling: {
-      percentage: 100
-      samplingType: 'fixed'
+  resource apimName_applicationinsights 'diagnostics' = {
+    name: 'applicationinsights'
+    properties: {
+      loggerId: apimName_appInsightsLogger_resource.id
+      alwaysLog: 'allErrors'
+      sampling: {
+        percentage: 100
+        samplingType: 'fixed'
+      }
     }
   }
 }

--- a/reference-implementations/AppGW-IAPIM-Func/bicep/backend/dnszone.bicep
+++ b/reference-implementations/AppGW-IAPIM-Func/bicep/backend/dnszone.bicep
@@ -2,7 +2,7 @@ param vnetName string
 param vnetRG string
 param privateEndpointName string
 param groupId string
-param storageName string 
+param storageName string
 param standardDomain string = 'windows.net'
 param domain string = 'privatelink.${groupId}.core.${standardDomain}'
 
@@ -14,39 +14,36 @@ resource vnet 'Microsoft.Network/virtualNetworks@2021-02-01' existing = {
 resource dnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
   name: domain
   location: 'global'
-}
 
-resource vnetLinks 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
-  name: '${domain}/${uniqueString(vnet.id)}'
-  location: 'global'
-  properties: {
-    virtualNetwork: {
-      id: vnet.id
+  resource vnetLinks 'virtualNetworkLinks' = {
+    name: uniqueString(vnet.id)
+    location: 'global'
+    properties: {
+      virtualNetwork: {
+        id: vnet.id
+      }
+      registrationEnabled: false
     }
-    registrationEnabled: false
   }
-  dependsOn: [
-    dnsZone
-  ]
 }
 
 resource dnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2020-03-01' = {
   name: '${privateEndpointName}/default'
   properties: {
     privateDnsZoneConfigs: [
-      {      
+      {
         name: '${storageName}-${groupId}-core-windows-net'
         properties: {
-          privateDnsZoneId: dnsZone.id          
+          privateDnsZoneId: dnsZone.id
         }
       }
     ]
   }
   dependsOn: [
-    vnetLinks
+    dnsZone::vnetLinks
   ]
 }
 
 output dnsZoneId string = dnsZone.id
-output vnetLinksLink string = vnetLinks.id
+output vnetLinksLink string = dnsZone::vnetLinks.id
 output dnsZoneGroupId string = dnsZoneGroup.id

--- a/reference-implementations/AppGW-IAPIM-Func/bicep/main.bicep
+++ b/reference-implementations/AppGW-IAPIM-Func/bicep/main.bicep
@@ -1,4 +1,4 @@
-targetScope='subscription'
+targetScope = 'subscription'
 
 // Parameters
 @description('A short name for the workload being deployed alphanumberic only')
@@ -20,6 +20,9 @@ param vmUsername string
 @description('The password for the Administrator user for all VMs created by this deployment')
 @secure()
 param vmPassword string
+
+@description('Valid SKU indicator for the VMs')
+param vmSize string = 'Standard_D4_v3'
 
 @description('The CI/CD platform to be used, and for which an agent will be configured for the ASE deployment. Specify \'none\' if no agent needed')
 @allowed([
@@ -48,11 +51,12 @@ param appGatewayCertType string
 
 param location string = deployment().location
 
+param resourceGroupTags object = {}
+
 // Variables
-var resourceSuffix = '${workloadName}-${environment}-${location}-001'
+var resourceSuffix = '${workloadName}-${environment}-${location}-${uniqueString(subscription().id)}'
 var networkingResourceGroupName = 'rg-networking-${resourceSuffix}'
 var sharedResourceGroupName = 'rg-shared-${resourceSuffix}'
-
 
 var backendResourceGroupName = 'rg-backend-${resourceSuffix}'
 
@@ -62,25 +66,28 @@ var apimResourceGroupName = 'rg-apim-${resourceSuffix}'
 var apimName = 'apim-${resourceSuffix}'
 var appGatewayName = 'appgw-${resourceSuffix}'
 
-
 resource networkingRG 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: networkingResourceGroupName
   location: location
+  tags: resourceGroupTags
 }
 
 resource backendRG 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: backendResourceGroupName
   location: location
+  tags: resourceGroupTags
 }
 
 resource sharedRG 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: sharedResourceGroupName
   location: location
+  tags: resourceGroupTags
 }
 
 resource apimRG 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: apimResourceGroupName
   location: location
+  tags: resourceGroupTags
 }
 
 module networking './networking/networking.bicep' = {
@@ -99,7 +106,7 @@ module backend './backend/backend.bicep' = {
   params: {
     workloadName: workloadName
     environment: environment
-    location: location    
+    location: location
     vnetName: networking.outputs.apimCSVNetName
     vnetRG: networkingRG.name
     backendSubnetId: networking.outputs.backEndSubnetid
@@ -107,7 +114,7 @@ module backend './backend/backend.bicep' = {
   }
 }
 
-var jumpboxSubnetId= networking.outputs.jumpBoxSubnetid
+var jumpboxSubnetId = networking.outputs.jumpBoxSubnetid
 var CICDAgentSubnetId = networking.outputs.CICDAgentSubnetId
 
 module shared './shared/shared.bicep' = {
@@ -128,10 +135,11 @@ module shared './shared/shared.bicep' = {
     resourceSuffix: resourceSuffix
     vmPassword: vmPassword
     vmUsername: vmUsername
+    vmSize: vmSize
   }
 }
 
-module apimModule 'apim/apim.bicep'  = {
+module apimModule 'apim/apim.bicep' = {
   name: 'apimDeploy'
   scope: resourceGroup(apimRG.name)
   params: {
@@ -141,11 +149,12 @@ module apimModule 'apim/apim.bicep'  = {
     appInsightsName: shared.outputs.appInsightsName
     appInsightsId: shared.outputs.appInsightsId
     appInsightsInstrumentationKey: shared.outputs.appInsightsInstrumentationKey
+    publicIpAddressId: networking.outputs.publicIp
   }
 }
 
 //Creation of private DNS zones
-module dnsZoneModule 'shared/dnszone.bicep'  = {
+module dnsZoneModule 'shared/dnszone.bicep' = {
   name: 'apimDnsZoneDeploy'
   scope: resourceGroup(sharedRG.name)
   dependsOn: [
@@ -167,14 +176,14 @@ module appgwModule 'gateway/appgw.bicep' = {
     dnsZoneModule
   ]
   params: {
-    appGatewayName:                 appGatewayName
-    appGatewayFQDN:                 appGatewayFqdn
-    location:                       location
-    appGatewaySubnetId:             networking.outputs.appGatewaySubnetid
-    primaryBackendEndFQDN:          '${apimName}.azure-api.net'
-    keyVaultName:                   shared.outputs.keyVaultName
-    keyVaultResourceGroupName:      sharedRG.name
-    appGatewayCertType:             appGatewayCertType
-    certPassword:                   certificatePassword
+    appGatewayName: appGatewayName
+    appGatewayFQDN: appGatewayFqdn
+    location: location
+    appGatewaySubnetId: networking.outputs.appGatewaySubnetid
+    primaryBackendEndFQDN: '${apimName}.azure-api.net'
+    keyVaultName: shared.outputs.keyVaultName
+    keyVaultResourceGroupName: sharedRG.name
+    appGatewayCertType: appGatewayCertType
+    certPassword: certificatePassword
   }
 }

--- a/reference-implementations/AppGW-IAPIM-Func/bicep/networking/networking.bicep
+++ b/reference-implementations/AppGW-IAPIM-Func/bicep/networking/networking.bicep
@@ -19,7 +19,6 @@
 // 
 // # Script end
 
-
 // Parameters
 @description('A short name for the workload being deployed')
 param workloadName string
@@ -54,7 +53,6 @@ param functionId string = '123131'
 // Variables
 var owner = 'APIM Const Set'
 
-
 var apimCSVNetName = 'vnet-apim-cs-${workloadName}-${deploymentEnvironment}-${location}'
 
 var bastionSubnetName = 'AzureBastionSubnet' // Azure Bastion subnet must have AzureBastionSubnet name, not 'snet-bast-${workloadName}-${deploymentEnvironment}-${location}'
@@ -64,7 +62,7 @@ var appGatewaySubnetName = 'snet-apgw-${workloadName}-${deploymentEnvironment}-$
 var privateEndpointSubnetName = 'snet-prep-${workloadName}-${deploymentEnvironment}-${location}-001'
 var backEndSubnetName = 'snet-bcke-${workloadName}-${deploymentEnvironment}-${location}-001'
 var apimSubnetName = 'snet-apim-${workloadName}-${deploymentEnvironment}-${location}-001'
-var bastionName = 'bastion-${workloadName}-${deploymentEnvironment}-${location}'	
+var bastionName = 'bastion-${workloadName}-${deploymentEnvironment}-${location}'
 var bastionIPConfigName = 'bastionipcfg-${workloadName}-${deploymentEnvironment}-${location}'
 
 var bastionSNNSG = 'nsg-bast-${workloadName}-${deploymentEnvironment}-${location}'
@@ -121,7 +119,6 @@ resource vnetApimCs 'Microsoft.Network/virtualNetworks@2021-02-01' = {
             id: jumpBoxNSG.id
           }
         }
-        
       }
       {
         name: appGatewaySubnetName
@@ -181,119 +178,119 @@ resource bastionNSG 'Microsoft.Network/networkSecurityGroups@2020-06-01' = {
   location: location
   properties: {
     securityRules: [
-        {
-          name: 'AllowHttpsInbound'
-          properties: {
-            priority: 120
-            protocol: 'Tcp'
-            destinationPortRange: '443'
-            access: 'Allow'
-            direction: 'Inbound'
-            sourcePortRange: '*'
-            sourceAddressPrefix: 'Internet'
-            destinationAddressPrefix: '*'
-          }              
+      {
+        name: 'AllowHttpsInbound'
+        properties: {
+          priority: 120
+          protocol: 'Tcp'
+          destinationPortRange: '443'
+          access: 'Allow'
+          direction: 'Inbound'
+          sourcePortRange: '*'
+          sourceAddressPrefix: 'Internet'
+          destinationAddressPrefix: '*'
         }
-        {
-          name: 'AllowGatewayManagerInbound'
-          properties: {
-            priority: 130
-            protocol: 'Tcp'
-            destinationPortRange: '443'
-            access: 'Allow'
-            direction: 'Inbound'
-            sourcePortRange: '*'
-            sourceAddressPrefix: 'GatewayManager'
-            destinationAddressPrefix: '*'
-          }              
+      }
+      {
+        name: 'AllowGatewayManagerInbound'
+        properties: {
+          priority: 130
+          protocol: 'Tcp'
+          destinationPortRange: '443'
+          access: 'Allow'
+          direction: 'Inbound'
+          sourcePortRange: '*'
+          sourceAddressPrefix: 'GatewayManager'
+          destinationAddressPrefix: '*'
         }
-        {
-            name: 'AllowAzureLoadBalancerInbound'
-            properties: {
-              priority: 140
-              protocol: 'Tcp'
-              destinationPortRange: '443'
-              access: 'Allow'
-              direction: 'Inbound'
-              sourcePortRange: '*'
-              sourceAddressPrefix: 'AzureLoadBalancer'
-              destinationAddressPrefix: '*'
-            }         
-          }     
-          {
-              name: 'AllowBastionHostCommunicationInbound'
-              properties: {
-                priority: 150
-                protocol: '*'
-                destinationPortRanges:[
-                  '8080'
-                  '5701'                
-                ] 
-                access: 'Allow'
-                direction: 'Inbound'
-                sourcePortRange: '*'
-                sourceAddressPrefix: 'VirtualNetwork'
-                destinationAddressPrefix: 'VirtualNetwork'
-              }              
-          }                    
-          {
-            name: 'AllowSshRdpOutbound'
-            properties: {
-              priority: 100
-              protocol: '*'
-              destinationPortRanges:[
-                '22'
-                '3389'
-              ]
-              access: 'Allow'
-              direction: 'Outbound'
-              sourcePortRange: '*'
-              sourceAddressPrefix: '*'
-              destinationAddressPrefix: 'VirtualNetwork'
-            }              
-          }       
-          {
-            name: 'AllowAzureCloudOutbound'
-            properties: {
-              priority: 110
-              protocol: 'Tcp'
-              destinationPortRange:'443'              
-              access: 'Allow'
-              direction: 'Outbound'
-              sourcePortRange: '*'
-              sourceAddressPrefix: '*'
-              destinationAddressPrefix: 'AzureCloud'
-            }              
-          }                                                         
-          {
-            name: 'AllowBastionCommunication'
-            properties: {
-              priority: 120
-              protocol: '*'
-              destinationPortRanges: [  
-                '8080'
-                '5701'
-              ]
-              access: 'Allow'
-              direction: 'Outbound'
-              sourcePortRange: '*'
-              sourceAddressPrefix: 'VirtualNetwork'
-              destinationAddressPrefix: 'VirtualNetwork'
-            }              
-          }                     
-          {
-            name: 'AllowGetSessionInformation'
-            properties: {
-              priority: 130
-              protocol: '*'
-              destinationPortRange: '80'
-              access: 'Allow'
-              direction: 'Outbound'
-              sourcePortRange: '*'
-              sourceAddressPrefix: '*'
-              destinationAddressPrefix: 'Internet'
-            }              
-          }                                                                   
+      }
+      {
+        name: 'AllowAzureLoadBalancerInbound'
+        properties: {
+          priority: 140
+          protocol: 'Tcp'
+          destinationPortRange: '443'
+          access: 'Allow'
+          direction: 'Inbound'
+          sourcePortRange: '*'
+          sourceAddressPrefix: 'AzureLoadBalancer'
+          destinationAddressPrefix: '*'
+        }
+      }
+      {
+        name: 'AllowBastionHostCommunicationInbound'
+        properties: {
+          priority: 150
+          protocol: '*'
+          destinationPortRanges: [
+            '8080'
+            '5701'
+          ]
+          access: 'Allow'
+          direction: 'Inbound'
+          sourcePortRange: '*'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationAddressPrefix: 'VirtualNetwork'
+        }
+      }
+      {
+        name: 'AllowSshRdpOutbound'
+        properties: {
+          priority: 100
+          protocol: '*'
+          destinationPortRanges: [
+            '22'
+            '3389'
+          ]
+          access: 'Allow'
+          direction: 'Outbound'
+          sourcePortRange: '*'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: 'VirtualNetwork'
+        }
+      }
+      {
+        name: 'AllowAzureCloudOutbound'
+        properties: {
+          priority: 110
+          protocol: 'Tcp'
+          destinationPortRange: '443'
+          access: 'Allow'
+          direction: 'Outbound'
+          sourcePortRange: '*'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: 'AzureCloud'
+        }
+      }
+      {
+        name: 'AllowBastionCommunication'
+        properties: {
+          priority: 120
+          protocol: '*'
+          destinationPortRanges: [
+            '8080'
+            '5701'
+          ]
+          access: 'Allow'
+          direction: 'Outbound'
+          sourcePortRange: '*'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationAddressPrefix: 'VirtualNetwork'
+        }
+      }
+      {
+        name: 'AllowGetSessionInformation'
+        properties: {
+          priority: 130
+          protocol: '*'
+          destinationPortRange: '80'
+          access: 'Allow'
+          direction: 'Outbound'
+          sourcePortRange: '*'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: 'Internet'
+        }
+      }
     ]
   }
 }
@@ -302,16 +299,14 @@ resource devOpsNSG 'Microsoft.Network/networkSecurityGroups@2020-06-01' = {
   name: devOpsSNNSG
   location: location
   properties: {
-    securityRules: [
-    ]
+    securityRules: []
   }
 }
 resource jumpBoxNSG 'Microsoft.Network/networkSecurityGroups@2020-06-01' = {
   name: jumpBoxSNNSG
   location: location
   properties: {
-    securityRules: [
-    ]
+    securityRules: []
   }
 }
 resource appGatewayNSG 'Microsoft.Network/networkSecurityGroups@2020-06-01' = {
@@ -378,8 +373,7 @@ resource privateEndpointNSG 'Microsoft.Network/networkSecurityGroups@2020-06-01'
   name: privateEndpointSNNSG
   location: location
   properties: {
-    securityRules: [
-    ]
+    securityRules: []
   }
 }
 
@@ -387,8 +381,7 @@ resource backEndNSG 'Microsoft.Network/networkSecurityGroups@2020-06-01' = {
   name: backEndSNNSG
   location: location
   properties: {
-    securityRules: [
-    ]
+    securityRules: []
   }
 }
 resource apimNSG 'Microsoft.Network/networkSecurityGroups@2020-06-01' = {
@@ -469,8 +462,15 @@ resource apimNSG 'Microsoft.Network/networkSecurityGroups@2020-06-01' = {
 resource pip 'Microsoft.Network/publicIPAddresses@2020-07-01' = {
   name: publicIPAddressName
   location: location
+  sku: {
+    name: 'Standard'
+    tier: 'Regional'
+  }
   properties: {
-    publicIPAllocationMethod: 'Dynamic'
+    publicIPAllocationMethod: 'Static'
+    dnsSettings: {
+      domainNameLabel: '${publicIPAddressName}dns'
+    }
   }
 }
 
@@ -485,13 +485,13 @@ resource pipBastion 'Microsoft.Network/publicIPAddresses@2020-07-01' = {
   properties: {
     publicIPAllocationMethod: 'Static'
     publicIPAddressVersion: 'IPv4'
-  }  
+  }
 }
 
 resource bastion 'Microsoft.Network/bastionHosts@2020-07-01' = {
   name: bastionName
-  location: location 
-  tags:  {
+  location: location
+  tags: {
     Owner: owner
   }
   properties: {
@@ -501,37 +501,35 @@ resource bastion 'Microsoft.Network/bastionHosts@2020-07-01' = {
         properties: {
           privateIPAllocationMethod: 'Dynamic'
           publicIPAddress: {
-            id: pipBastion.id             
+            id: pipBastion.id
           }
           subnet: {
-            id: '${vnetApimCs.id}/subnets/${bastionSubnetName}' 
+            id: '${vnetApimCs.id}/subnets/${bastionSubnetName}'
           }
         }
       }
     ]
   }
-} 
-
-
+}
 
 // Output section
 output apimCSVNetName string = apimCSVNetName
 output apimCSVNetId string = vnetApimCs.id
 
-output bastionSubnetName string = bastionSubnetName  
-output devOpsSubnetName string = devOpsSubnetName  
-output jumpBoxSubnetName string = jumpBoxSubnetName  
-output appGatewaySubnetName string = appGatewaySubnetName  
-output privateEndpointSubnetName string = privateEndpointSubnetName  
-output backEndSubnetName string = backEndSubnetName  
+output bastionSubnetName string = bastionSubnetName
+output devOpsSubnetName string = devOpsSubnetName
+output jumpBoxSubnetName string = jumpBoxSubnetName
+output appGatewaySubnetName string = appGatewaySubnetName
+output privateEndpointSubnetName string = privateEndpointSubnetName
+output backEndSubnetName string = backEndSubnetName
 output apimSubnetName string = apimSubnetName
 
-output bastionSubnetid string = '${vnetApimCs.id}/subnets/${bastionSubnetName}'  
-output CICDAgentSubnetId string = '${vnetApimCs.id}/subnets/${devOpsSubnetName}'  
-output jumpBoxSubnetid string = '${vnetApimCs.id}/subnets/${jumpBoxSubnetName}'  
-output appGatewaySubnetid string = '${vnetApimCs.id}/subnets/${appGatewaySubnetName}'  
-output privateEndpointSubnetid string = '${vnetApimCs.id}/subnets/${privateEndpointSubnetName}'  
-output backEndSubnetid string = '${vnetApimCs.id}/subnets/${backEndSubnetName}'  
-output apimSubnetid string = '${vnetApimCs.id}/subnets/${apimSubnetName}'  
+output bastionSubnetid string = '${vnetApimCs.id}/subnets/${bastionSubnetName}'
+output CICDAgentSubnetId string = '${vnetApimCs.id}/subnets/${devOpsSubnetName}'
+output jumpBoxSubnetid string = '${vnetApimCs.id}/subnets/${jumpBoxSubnetName}'
+output appGatewaySubnetid string = '${vnetApimCs.id}/subnets/${appGatewaySubnetName}'
+output privateEndpointSubnetid string = '${vnetApimCs.id}/subnets/${privateEndpointSubnetName}'
+output backEndSubnetid string = '${vnetApimCs.id}/subnets/${backEndSubnetName}'
+output apimSubnetid string = '${vnetApimCs.id}/subnets/${apimSubnetName}'
 
 output publicIp string = pip.id

--- a/reference-implementations/AppGW-IAPIM-Func/bicep/shared/createvmwindows.bicep
+++ b/reference-implementations/AppGW-IAPIM-Func/bicep/shared/createvmwindows.bicep
@@ -100,24 +100,23 @@ resource vm 'Microsoft.Compute/virtualMachines@2021-04-01' = {
       ]
     }
   }
-}
 
-// deploy CI/CD agent, if required
-resource vm_CustomScript 'Microsoft.Compute/virtualMachines/extensions@2021-04-01' = if (deployAgent) {
-  parent: vm
-  name: 'CustomScript'
-  location: location
-  properties: {
-    publisher: 'Microsoft.Compute'
-    type: 'CustomScriptExtension'
-    typeHandlerVersion: '1.10'
-    settings: {
-      fileUris: [
-        artifactsLocation
-      ]   
-    }
-    protectedSettings: {
-      commandToExecute: 'powershell.exe -ExecutionPolicy Unrestricted -Command ./agentsetup.ps1 -url ${accountName} -pat ${personalAccessToken} -agent ${AgentName} -pool ${poolName} -agenttype ${CICDAgentType} '
+  // deploy CI/CD agent, if required
+  resource vm_CustomScript 'extensions' = if (deployAgent) {
+    name: 'CustomScript'
+    location: location
+    properties: {
+      publisher: 'Microsoft.Compute'
+      type: 'CustomScriptExtension'
+      typeHandlerVersion: '1.10'
+      settings: {
+        fileUris: [
+          artifactsLocation
+        ]   
+      }
+      protectedSettings: {
+        commandToExecute: 'powershell.exe -ExecutionPolicy Unrestricted -Command ./agentsetup.ps1 -url ${accountName} -pat ${personalAccessToken} -agent ${AgentName} -pool ${poolName} -agenttype ${CICDAgentType} '
+      }
     }
   }
 }

--- a/reference-implementations/AppGW-IAPIM-Func/bicep/shared/dnszone.bicep
+++ b/reference-implementations/AppGW-IAPIM-Func/bicep/shared/dnszone.bicep
@@ -1,8 +1,7 @@
-
-param vnetName                  string
-param vnetRG                    string
-param apimName                  string
-param apimRG                    string
+param vnetName string
+param vnetRG string
+param apimName string
+param apimRG string
 
 /*
  Retrieve APIM and Virtual Network
@@ -37,6 +36,32 @@ resource gatewayDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
     vnet
   ]
   properties: {}
+
+  resource gatewayRecord 'A' = {
+    name: apimName
+    dependsOn: [
+      apim
+    ]
+    properties: {
+      aRecords: [
+        {
+          ipv4Address: apim.properties.privateIPAddresses[0]
+        }
+      ]
+      ttl: 36000
+    }
+  }
+
+  resource gatewayVnetLink 'virtualNetworkLinks' = {
+    name: 'gateway-vnet-dns-link'
+    location: 'global'
+    properties: {
+      registrationEnabled: true
+      virtualNetwork: {
+        id: vnet.id
+      }
+    }
+  }
 }
 
 resource portalDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
@@ -46,6 +71,32 @@ resource portalDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
     vnet
   ]
   properties: {}
+
+  resource portalRecord 'A' = {
+    name: apimName
+    dependsOn: [
+      apim
+    ]
+    properties: {
+      aRecords: [
+        {
+          ipv4Address: apim.properties.privateIPAddresses[0]
+        }
+      ]
+      ttl: 36000
+    }
+  }
+
+  resource portalVnetLink 'virtualNetworkLinks' = {
+    name: 'gateway-vnet-dns-link'
+    location: 'global'
+    properties: {
+      registrationEnabled: false
+      virtualNetwork: {
+        id: vnet.id
+      }
+    }
+  }
 }
 
 resource developerDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
@@ -55,6 +106,32 @@ resource developerDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
     vnet
   ]
   properties: {}
+
+  resource developerRecord 'A' = {
+    name: apimName
+    dependsOn: [
+      apim
+    ]
+    properties: {
+      aRecords: [
+        {
+          ipv4Address: apim.properties.privateIPAddresses[0]
+        }
+      ]
+      ttl: 36000
+    }
+  }
+
+  resource developerVnetLink 'virtualNetworkLinks' = {
+    name: 'gateway-vnet-dns-link'
+    location: 'global'
+    properties: {
+      registrationEnabled: false
+      virtualNetwork: {
+        id: vnet.id
+      }
+    }
+  }
 }
 
 resource managementDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
@@ -64,6 +141,32 @@ resource managementDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
     vnet
   ]
   properties: {}
+
+  resource managementRecord 'A' = {
+    name: apimName
+    dependsOn: [
+      apim
+    ]
+    properties: {
+      aRecords: [
+        {
+          ipv4Address: apim.properties.privateIPAddresses[0]
+        }
+      ]
+      ttl: 36000
+    }
+  }
+
+  resource managementVnetLink 'virtualNetworkLinks' = {
+    name: 'gateway-vnet-dns-link'
+    location: 'global'
+    properties: {
+      registrationEnabled: false
+      virtualNetwork: {
+        id: vnet.id
+      }
+    }
+  }
 }
 
 resource scmDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
@@ -73,158 +176,30 @@ resource scmDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
     vnet
   ]
   properties: {}
-}
 
-// A Records
-
-resource gatewayRecord 'Microsoft.Network/privateDnsZones/A@2020-06-01' = {
-  name: 'azure-api.net/${apimName}'
-  dependsOn: [
-    apim
-    gatewayDnsZone
-  ]
-  properties: {
-    aRecords: [
-      {
-        ipv4Address: apim.properties.privateIPAddresses[0]
-      }
+  resource scmRecord 'A' = {
+    name: apimName
+    dependsOn: [
+      apim
     ]
-    ttl: 36000
-  }
-}
-
-resource portalRecord 'Microsoft.Network/privateDnsZones/A@2020-06-01' = {
-  name: 'portal.azure-api.net/${apimName}'
-  dependsOn: [
-    apim
-    portalDnsZone
-  ]
-  properties: {
-    aRecords: [
-      {
-        ipv4Address: apim.properties.privateIPAddresses[0]
-      }
-    ]
-    ttl: 36000
-  }
-}
-
-resource developerRecord 'Microsoft.Network/privateDnsZones/A@2020-06-01' = {
-  name: 'developer.azure-api.net/${apimName}'
-  dependsOn: [
-    apim
-    developerDnsZone
-  ]
-  properties: {
-    aRecords: [
-      {
-        ipv4Address: apim.properties.privateIPAddresses[0]
-      }
-    ]
-    ttl: 36000
-  }
-}
-
-resource managementRecord 'Microsoft.Network/privateDnsZones/A@2020-06-01' = {
-  name: 'management.azure-api.net/${apimName}'
-  dependsOn: [
-    apim
-    managementDnsZone
-  ]
-  properties: {
-    aRecords: [
-      {
-        ipv4Address: apim.properties.privateIPAddresses[0]
-      }
-    ]
-    ttl: 36000
-  }
-}
-
-resource scmRecord 'Microsoft.Network/privateDnsZones/A@2020-06-01' = {
-  name: 'scm.azure-api.net/${apimName}'
-  dependsOn: [
-    apim
-    scmDnsZone
-  ]
-  properties: {
-    aRecords: [
-      {
-        ipv4Address: apim.properties.privateIPAddresses[0]
-      }
-    ]
-    ttl: 36000
-  }
-}
-
-// Vnet Links
-
-resource gatewayVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
-  name: 'azure-api.net/gateway-vnet-dns-link'
-  location: 'global'
-  dependsOn: [
-    gatewayDnsZone
-  ]
-  properties: {
-    registrationEnabled: true
-    virtualNetwork: {
-      id: vnet.id
+    properties: {
+      aRecords: [
+        {
+          ipv4Address: apim.properties.privateIPAddresses[0]
+        }
+      ]
+      ttl: 36000
     }
   }
-}
 
-resource portalVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
-  name: 'portal.azure-api.net/gateway-vnet-dns-link'
-  location: 'global'
-  dependsOn: [
-    portalDnsZone
-  ]
-  properties: {
-    registrationEnabled: false
-    virtualNetwork: {
-      id: vnet.id
-    }
-  }
-}
-
-resource developerVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
-  name: 'developer.azure-api.net/gateway-vnet-dns-link'
-  location: 'global'
-  dependsOn: [
-    developerDnsZone
-  ]
-  properties: {
-    registrationEnabled: false
-    virtualNetwork: {
-      id: vnet.id
-    }
-  }
-}
-
-resource managementVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
-  name: 'management.azure-api.net/gateway-vnet-dns-link'
-  location: 'global'
-  dependsOn: [
-    managementDnsZone
-  ]
-  properties: {
-    registrationEnabled: false
-    virtualNetwork: {
-      id: vnet.id
-    }
-  }
-}
-
-resource scmVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
-  name: 'scm.azure-api.net/gateway-vnet-dns-link'
-  location: 'global'
-  dependsOn: [
-    scmDnsZone
-  ]
-  properties: {
-    registrationEnabled: false
-    virtualNetwork: {
-      id: vnet.id
+  resource scmVnetLink 'virtualNetworkLinks' = {
+    name: 'gateway-vnet-dns-link'
+    location: 'global'
+    properties: {
+      registrationEnabled: false
+      virtualNetwork: {
+        id: vnet.id
+      }
     }
   }
 }

--- a/reference-implementations/AppGW-IAPIM-Func/bicep/shared/shared.bicep
+++ b/reference-implementations/AppGW-IAPIM-Func/bicep/shared/shared.bicep
@@ -1,4 +1,4 @@
-targetScope='resourceGroup'
+targetScope = 'resourceGroup'
 // Parameters
 @description('Azure location to which the resources are to be deployed')
 param location string
@@ -15,6 +15,9 @@ param vmUsername string
 @description('The password for the Administrator user for all VMs created by this deployment')
 @secure()
 param vmPassword string
+
+@description('Valid SKU indicator for the VM')
+param vmSize string = 'Standard_D4_v3'
 
 @description('The CI/CD platform to be used, and for which an agent will be configured for the ASE deployment. Specify \'none\' if no agent needed')
 @allowed([
@@ -60,7 +63,7 @@ module appInsights './azmon.bicep' = {
   }
 }
 
-module vm_devopswinvm './createvmwindows.bicep' = if (toLower(CICDAgentType)!='none') {
+module vm_devopswinvm './createvmwindows.bicep' = if (toLower(CICDAgentType) != 'none') {
   name: 'devopsvm'
   scope: resourceGroup(resourceGroupName)
   params: {
@@ -73,6 +76,7 @@ module vm_devopswinvm './createvmwindows.bicep' = if (toLower(CICDAgentType)!='n
     personalAccessToken: personalAccessToken
     CICDAgentType: CICDAgentType
     deployAgent: true
+    vmSize: vmSize
   }
 }
 
@@ -86,6 +90,7 @@ module vm_jumpboxwinvm './createvmwindows.bicep' = {
     password: vmPassword
     CICDAgentType: CICDAgentType
     vmName: 'jumpbox-${environment}'
+    vmSize: vmSize
   }
 }
 
@@ -97,7 +102,7 @@ resource key_vault 'Microsoft.KeyVault/vaults@2019-09-01' = {
     sku: {
       family: 'A'
       name: 'standard'
-    }    
+    }
     accessPolicies: [
       // {
       //   tenantId: 'string'
@@ -126,7 +131,7 @@ resource key_vault 'Microsoft.KeyVault/vaults@2019-09-01' = {
 output appInsightsConnectionString string = appInsights.outputs.appInsightsConnectionString
 output CICDAgentVmName string = vm_devopswinvm.name
 output jumpBoxvmName string = vm_jumpboxwinvm.name
-output appInsightsName string=appInsights.outputs.appInsightsName
-output appInsightsId string=appInsights.outputs.appInsightsId
-output appInsightsInstrumentationKey string=appInsights.outputs.appInsightsInstrumentationKey
+output appInsightsName string = appInsights.outputs.appInsightsName
+output appInsightsId string = appInsights.outputs.appInsightsId
+output appInsightsInstrumentationKey string = appInsights.outputs.appInsightsInstrumentationKey
 output keyVaultName string = key_vault.name

--- a/src/functions.csproj
+++ b/src/functions.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
When deploying the APIM accelerator to an Azure subscription for evaluation, I ran into several issues that I am attempting to resolve here.

1. VM Sku was unavailable and no parameter in main.bicep allowed for selecting a different one
2. My Azure subscription has Microsoft-recommended policies requiring tags at the resource group level
3. Using the example deployment command resulted in name collisions for storage accounts and web apps
5. Azure Function was deployed as Framework 3 which is deprecated
6. APIM is deployed using STV1 which is also slated for depreciation
7. Linter warnings about not using parent parameters on some resources
8. Linter warning about resource name not having a minimum number of chars

This PR resolves the above with the below

1. Add a VM Sku parameter to the main.bicep file and set the default to match the createvmwindows.bicep file
2. Add a resourceGroupTags parameter with a default of empty array this will allow others to provide tags at deployment time
3. Added a unique string to some parameter names to ensure naming collisions won't happen
4. Updated the Azure function resource to use ~4 framework
5. Added parameter publicIpAddressId to apim.bicep passing the public IP for apim and allowing stv2 to be provisioned
6. switched to using child resources
7. cleaned up the warning by changing the order of some functions in the storage account name variable declaration