### PR TITLE
apim-baseline Improvements

### DIFF
--- a/scenarios/apim-baseline/bicep/apim/apim.bicep
+++ b/scenarios/apim-baseline/bicep/apim/apim.bicep
@@ -32,6 +32,9 @@ param appInsightsName string
 param appInsightsId string
 param appInsightsInstrumentationKey string
 
+param keyVaultName                  string
+param keyVaultResourceGroupName     string
+
 /*
  * Resources
 */
@@ -42,6 +45,9 @@ resource apimName_resource 'Microsoft.ApiManagement/service@2020-12-01' = {
   sku:{
     capacity: capacity
     name: skuName
+  }
+  identity: {
+    type: 'SystemAssigned'
   }
   properties:{
     virtualNetworkType: 'Internal'
@@ -75,5 +81,14 @@ resource apimName_applicationinsights 'Microsoft.ApiManagement/service/diagnosti
       percentage: 100
       samplingType: 'fixed'
     }
+  }
+}
+
+module kvaccess './modules/kvaccess.bicep' = {
+  name: 'kvaccess'
+  scope: resourceGroup(keyVaultResourceGroupName)
+  params: {
+    managedIdentity:    apimName_resource.identity
+    keyVaultName:       keyVaultName
   }
 }

--- a/scenarios/apim-baseline/bicep/apim/modules/kvaccess.bicep
+++ b/scenarios/apim-baseline/bicep/apim/modules/kvaccess.bicep
@@ -1,0 +1,24 @@
+param keyVaultName            string
+param managedIdentity         object   
+
+resource accessPolicyGrant 'Microsoft.KeyVault/vaults/accessPolicies@2019-09-01' = {
+  name: '${keyVaultName}/add'
+  properties: {
+    accessPolicies: [
+      {
+        objectId: managedIdentity.principalId
+        tenantId: managedIdentity.tenantId
+        permissions: {
+          secrets: [ 
+            'get' 
+            'list'
+          ]
+          certificates: [
+            'get'
+            'list'
+          ]
+        }                  
+      }
+    ]
+  }
+}

--- a/scenarios/apim-baseline/bicep/main.bicep
+++ b/scenarios/apim-baseline/bicep/main.bicep
@@ -83,6 +83,8 @@ module apimModule 'apim/apim.bicep'  = {
     appInsightsName: shared.outputs.appInsightsName
     appInsightsId: shared.outputs.appInsightsId
     appInsightsInstrumentationKey: shared.outputs.appInsightsInstrumentationKey
+    keyVaultName: shared.outputs.keyVaultName
+    keyVaultResourceGroupName: sharedRG.name
   }
 }
 
@@ -103,7 +105,7 @@ module dnsZoneModule 'shared/dnszone.bicep'  = {
 
 module appgwModule 'gateway/appgw.bicep' = {
   name: 'appgwDeploy'
-  scope: resourceGroup(apimRG.name)
+  scope: resourceGroup(networkingRG.name)
   dependsOn: [
     apimModule
     dnsZoneModule


### PR DESCRIPTION

- Updated AGW to use WAF policies instead of global as per product direction
- Enabled MI on APIM and granted access to key vault to allow key vault referenced named values
- Removed port 80 listener from App Gateway
- Moved App Gateway to networking resource group