### PR TITLE
Add .gitattributes for .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Set bash scripts to use LF line endings regardless of the platform
+# used to clone the code
+*.sh text eol=lf


### PR DESCRIPTION
Add `.gitattributes` file to configure `*.sh` to always have LF line endings regardless of whether the code is cloned on Windows/Linux/Mac