### PR TITLE
Set APIM minimum API version

### DIFF
--- a/scenarios/apim-baseline/bicep/apim/apim.bicep
+++ b/scenarios/apim-baseline/bicep/apim/apim.bicep
@@ -70,6 +70,9 @@ resource apimName_resource 'Microsoft.ApiManagement/service@2020-12-01' = {
     virtualNetworkConfiguration: {
       subnetResourceId: apimSubnetId
     }
+    apiVersionConstraint: {
+      minApiVersion: '2019-12-01'
+    }
   }
 }
 

--- a/scenarios/apim-baseline/terraform/modules/apim/apim.tf
+++ b/scenarios/apim-baseline/terraform/modules/apim/apim.tf
@@ -28,6 +28,8 @@ resource "azurerm_api_management" "apim_internal" {
 
   sku_name = var.skuName
 
+  min_api_version = "2019-12-01"
+
   virtual_network_configuration {
     subnet_id = var.apimSubnetId
   }

--- a/scenarios/scripts/terraform/azure-backend-sample.sh
+++ b/scenarios/scripts/terraform/azure-backend-sample.sh
@@ -65,7 +65,7 @@ create_storage_account() {
 }
 
 # Validate or create resource group
-if [[ $(az group exists --name "$TF_BACKEND_RESOURCE_GROUP_NAME") == "false" ]]; then
+if [[ $(az group exists --name "$TF_BACKEND_RESOURCE_GROUP_NAME" --output tsv) == "false" ]]; then
   if [[ $auto_confirm == true ]]; then
     create_resource_group
   else


### PR DESCRIPTION
- set min api version in both Bicep and Terraform deployments to `2019-12-01` as per portal advisary
![image](https://github.com/user-attachments/assets/ce5060c2-31ee-44a4-a5f5-48a5a165f35d)

- Force tsv output in script for existence test check